### PR TITLE
Changed the gather rates of Fish traps in aoc to the same value as in…

### DIFF
--- a/web/stats/aoc_gathering.json
+++ b/web/stats/aoc_gathering.json
@@ -92,15 +92,15 @@
 		},
 		{
 			"type": "Food",
-			"source": "Fish traps",
-			"speed": "0.206 F/s",
-			"note": "Rarely used, usually only when fish has run out. Gives quite good wood to food ratio"
+			"source": "Fish traps with japanese",
+			"speed": "0.325 - 0.365 F/s",
+			"note": "Usually used fish has run out. Gives quite good wood to food ratio. Japanese get faster fishing ship by 5% in each age. Experimental results - 0.325 F/s in Dark, 0.338 F/s in Feudal, 0.351 F/s in Castle and 0.365 F/s in Imperial age. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>."
 		},
 		{
 			"type": "Food",
-			"source": "Fish traps with japanese",
-			"speed": "0.216 - 0.247 F/s",
-			"note": "Japanese have a bonus to their fishing ship fishing speeds 5% in Dark, 10% in Feudal, 15% in Castle and 20% in Imperial. These correspond to 0.216 F/s in Dark age, 0.227 F/s in Feudal Age, 0.236 F/s in Castle age and 0.247 F/s in Imperial Age. Note these values hold only when the fishing ship doesn't have to move to drop off resources. Real values will be lower based on the distance."
+			"source": "Fish traps",
+			"speed": "0.311 F/s",
+			"note": "Usually used fish has run out. Gives quite good wood to food ratio. In realistic tests 0.311. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>."
 		},
 		{
 			"type": "Wood",

--- a/web/stats/dlc_gathering.php
+++ b/web/stats/dlc_gathering.php
@@ -4,12 +4,12 @@ $changes_json = <<<JSON
 {
 	 "Fish traps with japanese": {
 			"speed": "0.325 - 0.365 F/s",
-			"note": "Usually used fish has run out. Gives quite good wood to food ratio. In forgotten the work rate was increased from 0.75 -> 1.25. So theoretically that would mean if it's directly proportional to the old value 1.25*0.206/0.75 = 0.343 F/s. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>. Japanese get faster fishing ship by 5% in each age. Experimental results - 0.325 F/s in Dark, 0.338 F/s in Feudal, 0.351 F/s in Castle and 0.365 F/s in Imperial age."
+			"note": "Usually used fish has run out. Gives quite good wood to food ratio. Japanese get faster fishing ship by 5% in each age. Experimental results - 0.325 F/s in Dark, 0.338 F/s in Feudal, 0.351 F/s in Castle and 0.365 F/s in Imperial age. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>. The new \"Gillnets\" technology in Castle Age increases this by 25%."
 		},
 	 "Fish traps": {
 		"speed": "0.311 F/s",
-		"note": "Usually used fish has run out. Gives quite good wood to food ratio. In forgotten the work rate was increased from 0.75 -> 1.25. So theoretically that would mean if it's directly proportional to the old value 1.25*0.206/0.75 = 0.343 F/s. In realistic tests 0.311. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>."
-	},
+		"note": "Usually used fish has run out. Gives quite good wood to food ratio. In realistic tests 0.311. Thanks to Jineapple for the <a href=\"http://aoczone.net/viewtopic.php?f=186&t=116696&p=460336#p460077\">tests</a>. The new \"Gillnets\" technology in Castle Age increases this by 25%."
+		},
 	"Sheep/Turkey/Cow": {
 			"source": "Livestock",
 			"note": "Includes sheep, turkey, cow and goat. Livestock have a interesting attribute: they can be positioned underneath the Town Center, nullifying the walk time. Usually only two livestock are placed in the Town Center per time (yes, this requires some micromanagement and experience). Probably, the only downside is that you have to search for them."
@@ -68,7 +68,7 @@ $new_gather_json = <<<JSON
 		"type": "Food",
 		"source": "Farming with berbers",
 		"speed": "0.315 F/s",
-		"note": "This was test by Spirit of the Law (<a href='https://www.youtube.com/watch?v=GRutI6IMjkY'>link</a>). Berbers get only a slight improvement 1-3% on farming, so their faster walking villagers doesn't affect the farming speed much."
+		"note": "This was tested by Spirit of the Law (<a href='https://www.youtube.com/watch?v=GRutI6IMjkY'>link</a>). Berbers get only a slight improvement 1-3% on farming, so their faster walking villagers doesn't affect the farming speed much."
 	}
 ]
 JSON;


### PR DESCRIPTION
… the expansions. The work rate increase actually happened with 1.0c, not with FE. However, Gillnets makes Fish traps more viable in the expansions