### PR TITLE
Click to search unique units and techs from civ overview (+typo)

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -11,6 +11,11 @@ body {
 	color: #3b3a36;
 }
 
+.searchable{
+	cursor: pointer;
+	color: #337ab7;
+}
+
 .searchbox {
 	float: right;
 	display: inline-block;

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -799,8 +799,52 @@ function initTables(version) {
         	},
             { "data": "name", "class": "bold-cell", "responsivePriority": 1},
             { "data": "ct", "class": "dt-center", "responsivePriority": 2 },
-            { "data": "uu", "class": "dt-center", "responsivePriority": 2 },
-            { "data": "ut", "class": "dt-center", "responsivePriority": 2 },
+            { "data": "uu", "class": "dt-center", "responsivePriority": 2, "render":function(data, type, row){
+		    let items = data.split(",");
+		    let retval = ""
+		    for(item of items){
+			item = $.trim(item);
+			let bracketindex = item.indexOf("(");
+			let unit = item;
+			let comment = "";
+			if( bracketindex > -1 ){
+				unit = $.trim(item.substring(0, bracketindex));
+				comment = item.substring(bracketindex, item.length);
+			}
+			retval += "<span class='searchable' onclick=\"dosearch('"+unit+"')\">"+unit+"</span>";
+			if(comment != ""){
+				retval += " "+comment;
+			}
+			retval += ", ";
+		    }
+		    return retval.substring(0, retval.length - 2);
+		    
+	        } 
+            },
+	    { "data": "ut", "class": "dt-center", "responsivePriority": 2, "render":function(data, type, row){
+		    let items = data.split(",");
+		    let retval = ""
+		    for(item of items){
+			    item = item.replace("<br />", "");
+			    item = $.trim(item);
+			    let bracketindex = item.indexOf("(");
+			    let tech = item;
+			    let comment = "";
+			    if( bracketindex > -1 ){
+				    tech = $.trim(item.substring(0, bracketindex));
+				    comment = item.substring(bracketindex, item.length);
+			    }
+			    retval += "<span class='searchable' onclick=\"dosearch('"+tech+"')\">"+tech+"</span>";
+			    if(comment != ""){
+				    retval += " "+comment;
+			    }
+			    retval += ", <br>";
+		    }
+		    return retval.substring(0, retval.length - 6);
+		    
+		} 
+		    
+            },
             { "data": "tb", "class": "dt-center", "responsivePriority": 2 },
             { "data": "tt", "class": "dt-center",
             	"render" : function(data, type, row) {
@@ -922,6 +966,11 @@ function initTables(version) {
 
 var ENABLED_SECTIONS = ['units', 'structures', 'techs', 'civs', 'gathers'];
 var SECTION_COUNT = ENABLED_SECTIONS.length;
+
+function dosearch(str){
+	$("#global-search").val(str);
+	update_search();
+}
 
 function update_search() {
 

--- a/web/stats/aoc_civilizations.json
+++ b/web/stats/aoc_civilizations.json
@@ -174,7 +174,7 @@
 			"name": "Vikings",
 			"ver": "k", 
 			"ct": "Infantry and naval",
-			"uu": "Berserker, Longboat",
+			"uu": "Berserk, Longboat",
 			"ut": "Berserkergang",
 			"tb": "Docks are 25% cheaper",
 			"bs": "<ul> <li>Warships cost 20% less</li> <li>Infantry have +10% HP in Feudal Age, +15% in Castle Age, <br /> +20% in Imperial Age</li> <li>Wheelbarrow and Hand Cart are free</li> </ul>",

--- a/web/stats/aoc_technologies.json
+++ b/web/stats/aoc_technologies.json
@@ -1267,7 +1267,7 @@
 			"ver": "k",
 			"age": "3",
 			"cost": "500F 850G",
-			"for": "Vikings, Berserkers regenerate 2x faster - 2 HP every 3 seconds",
+			"for": "Vikings, Berserks regenerate 2x faster - 2 HP every 3 seconds",
 			"time": "0:40",
 			"t": ""
 		},


### PR DESCRIPTION
Something that has always been bugging me was that we could not see details of unique techs in the civilization overview. I made them clickable so they would trigger a search for the tech's name. 
Certainly not an ideal solution, but it helps. What do you think?

Also renamed Berserker to Berserk so it would actually be found.